### PR TITLE
SERVICES-1069 - update services-api docs for payment_type

### DIFF
--- a/source/includes/orders.md
+++ b/source/includes/orders.md
@@ -296,7 +296,7 @@ email | no | Email of the user.
 
 Parameter | Required | Description
 --------- | ------- | -----------
-payment_type | yes | Type of payment method. Possible values ```cash```, ```credit_card```.
+payment_type | yes | Type of payment method used 
 amount | yes | Amount charged in cents
 
 ### Line Item object


### PR DESCRIPTION
Changing `payment_type` to reflect that it is now a freeform string field.